### PR TITLE
Login form path &  Retrieving courses by href

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -1,6 +1,6 @@
 const { Moodle } = require("moodle-scrape");
 const undici = require("undici");
- 
+
 const url = ""; // https://example.com
 const username = "";
 const password = "";
@@ -8,21 +8,24 @@ const password = "";
 const moodle = new Moodle(undici.fetch, url);
 
 async function init() {
-	console.time('-- login() time')
-	const success = await moodle.login(username, password, false);
-	console.timeEnd('-- login() time')
+  console.time("-- login() time");
+  const success = await moodle.login(username, password, {
+    refresh: false,
+    loginFormPath: "login/index.php",
+  });
+  console.timeEnd("-- login() time");
 
-	if(!success) {
-		return console.log("ERROR: Login failed.");
-	}
+  if (!success) {
+    return console.log("ERROR: Login failed.");
+  }
 
-	console.time('-- getInfo() time')
-	await moodle.refresh();
-	console.timeEnd('-- getInfo() time')
+  console.time("-- getInfo() time");
+  await moodle.refresh();
+  console.timeEnd("-- getInfo() time");
 
-	console.log(moodle.user);
-    console.log(moodle.courses);
-	console.log(moodle.tasks);
+  console.log(moodle.user);
+  console.log(moodle.courses);
+  console.log(moodle.tasks);
 }
 
 init();

--- a/src/Moodle.ts
+++ b/src/Moodle.ts
@@ -1,111 +1,155 @@
-import { load } from 'cheerio';
+import { load } from "cheerio";
 
-import { Course, Task, User, Fetch } from './types/types'
+import { Course, Task, User, Fetch, Options } from "./types/types";
+
+const defaultOptions: Options = {
+  refresh: true,
+};
 
 export class Moodle {
-    url: string;
-    fetch: Fetch;
-    cookies: string | undefined;
-    user: User | null;
-    courses: Array<Course>;
-    tasks: Array<Task>;
+  url: string;
+  fetch: Fetch;
+  cookies: string | undefined;
+  user: User | null;
+  courses: Array<Course>;
+  tasks: Array<Task>;
 
-    /**
-     * Creates a new scraper instance for a certain Moodle site
-     * @param { Fetch }     fetch   The fetch method to use (e.g. undici or the built-in global fetch)
-     * @param { string }    url     URL of the Moodle site
-     * @example const moodle = new Moodle(fetch, "https://examplesite.com");
-     */
-    constructor(fetch: Fetch, url: string) {
-        this.fetch = fetch;
-        this.url = url.endsWith("/") ? url.slice(0, -1) : url;
-        this.cookies = undefined;
-        this.user = null;
-        this.courses = [];
-        this.tasks = [];
+  /**
+   * Creates a new scraper instance for a certain Moodle site
+   * @param { Fetch }     fetch   The fetch method to use (e.g. undici or the built-in global fetch)
+   * @param { string }    url     URL of the Moodle site
+   * @example const moodle = new Moodle(fetch, "https://examplesite.com");
+   */
+  constructor(fetch: Fetch, url: string) {
+    this.fetch = fetch;
+    this.url = url.endsWith("/") ? url.slice(0, -1) : url;
+    this.cookies = undefined;
+    this.user = null;
+    this.courses = [];
+    this.tasks = [];
+  }
+
+  appendToURL(path: string = "") {
+    let separator = "/";
+    if (path.startsWith(separator) || this.url.endsWith(separator)) {
+      separator = "";
     }
+    return `${this.url}${separator}${path}`;
+  }
 
-    /**
-     * 
-     * @param { string } username
-     * @param { string } password
-     * @param { boolean } refresh Whether to call Moodle.refresh() automatically after logging in. True by default.
-     */
-    async login(username: string, password: string, refresh: boolean = true) {
-        const form = new URLSearchParams();
-        form.append('username', username);
-        form.append('password', password);
+  /**
+   *
+   * @param { string } username
+   * @param { string } password
+   * @param { Options } options Extra login options
+   * @param { boolean } options.refresh  Whether to call Moodle.refresh() automatically after logging in
+   * @param { string } options.loginFormPath  If the login form is not located in the url index, this can be set to the form location
+   *
+   * @example moodle.login('username', 'password', {refresh: true, loginFormPath: 'login/index.php'})
+   */
+  async login(
+    username: string,
+    password: string,
+    options: Options = defaultOptions
+  ) {
+    const form = new URLSearchParams();
+    form.append("username", username);
+    form.append("password", password);
+    const loginForm = this.appendToURL(options.loginFormPath);
 
-		let res = await this.fetch(this.url);
-		const body = await res.text();
-		const $ = load(body);
-        
-		form.append('logintoken', $("[name='logintoken']")[0].attribs.value);
+    let res = await this.fetch(loginForm);
+    const body = await res.text();
+    const $ = load(body);
 
-		res = await this.fetch(`${this.url}/login/index.php`, {
-			headers: { 'cookie': res.headers.get('set-cookie')?.split('Secure, ').find((c: String) => c.startsWith("MoodleSession"))  || "" },
-			method: 'POST',
-			body: form,
-			redirect: 'manual',
-            credentials: 'include'
-		});
-		this.cookies = res.headers.get('set-cookie')?.split('Secure, ').find((c: String) => c.startsWith("MoodleSession"));
+    form.append("logintoken", $("[name='logintoken']")[0].attribs.value);
 
-        if(this.cookies && refresh === true) {
-            await this.refresh();
-        }
-		return !!this.cookies;
+    res = await this.fetch(this.appendToURL("/login/index.php"), {
+      headers: {
+        cookie:
+          res.headers
+            .get("set-cookie")
+            ?.split("Secure, ")
+            .find((c: String) => c.startsWith("MoodleSession")) || "",
+      },
+      method: "POST",
+      body: form,
+      redirect: "manual",
+      credentials: "include",
+    });
+    this.cookies = res.headers
+      .get("set-cookie")
+      ?.split("Secure, ")
+      .find((c: String) => c.startsWith("MoodleSession"));
+
+    if (this.cookies && options.refresh === true) {
+      await this.refresh();
     }
+    return !!this.cookies;
+  }
 
-    /**
-     * Fetches the user data and stores them in the Moodle instance
-     * @param cookies optional
-     */
-    async refresh(cookies = this.cookies) {
-        const res = await this.fetch(`${this.url}/calendar/view.php?view=upcoming`, {
-            headers: { 'cookie': cookies || "" }
-        });
-        const body = await res.text();
-        const $ = load(body);
+  /**
+   * Fetches the user data and stores them in the Moodle instance
+   * @param cookies optional
+   */
+  async refresh(cookies = this.cookies) {
+    const res = await this.fetch(
+      `${this.url}/calendar/view.php?view=upcoming`,
+      {
+        headers: { cookie: cookies || "" },
+      }
+    );
+    const body = await res.text();
+    const $ = load(body);
 
-        try {
-            // parse courses
-            this.courses = $("#main-header .visible1 > a").map((_, el) => {
-                return {
-                    id: parseInt(el.attribs.href.split("?id=")[1]),
-                    name: el.attribs.title,
-                    tasks: []
-                }
-            }).toArray();
+    try {
+      // parse courses
+      this.courses = $("#main-header .visible1 > a")
+        .map((_, el) => {
+          return {
+            id: parseInt(el.attribs.href.split("?id=")[1]),
+            name: el.attribs.title,
+            tasks: [],
+          };
+        })
+        .toArray();
 
-            // parse tasks
-            this.tasks = $(".event").map((i, el) => {
-                return {
-                    id: parseInt(el.attribs["data-event-id"]),
-                    name: el.attribs["data-event-title"],
-                    description: $($(".description-content").get(i)).text(),
-                    deadline: $($(".description > .row:not(.mt-1) > .col-xs-11").get(i)).text(),
-                    course: this.courses.find(e => e.id === parseInt(el.attribs["data-course-id"])) as Course
-                }
-            }).toArray();
+      // parse tasks
+      this.tasks = $(".event")
+        .map((i, el) => {
+          return {
+            id: parseInt(el.attribs["data-event-id"]),
+            name: el.attribs["data-event-title"],
+            description: $($(".description-content").get(i)).text(),
+            deadline: $(
+              $(".description > .row:not(.mt-1) > .col-xs-11").get(i)
+            ).text(),
+            course: this.courses.find(
+              (e) => e.id === parseInt(el.attribs["data-course-id"])
+            ) as Course,
+          };
+        })
+        .toArray();
 
-            // put the tasks in their corresponding courses
-            this.tasks.forEach(t => {
-                this.courses.find(c => c.id === t.course.id)?.tasks.push(t);
-            });
+      // put the tasks in their corresponding courses
+      this.tasks.forEach((t) => {
+        this.courses.find((c) => c.id === t.course.id)?.tasks.push(t);
+      });
 
-            // parse user
-            this.user = {
-                id: parseInt($(".theme-loginform-form > a").attr("href")?.split("?id=")[1] as string),
-                name: $(".usertext").text(),
-                picture: $(".welcome_userpicture").attr("src") as string
-            };
+      // parse user
+      this.user = {
+        id: parseInt(
+          $(".theme-loginform-form > a")
+            .attr("href")
+            ?.split("?id=")[1] as string
+        ),
+        name: $(".usertext").text(),
+        picture: $(".welcome_userpicture").attr("src") as string,
+      };
 
-            return true;
-
-        } catch(err) {
-            console.log(err);
-            return false;
-        }
+      return true;
+    } catch (err) {
+      console.log(err);
+      return false;
     }
+  }
 }

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -4,7 +4,7 @@ export interface Task {
     id: number;
     name: string;
     description: string;
-    deadline: string;
+    deadline: Date;
     course: Course;
 }
 export interface User {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -17,3 +17,8 @@ export interface Course {
     name: string;
     tasks: Array<Task>;
 }
+
+export interface Options{
+    refresh?: boolean;
+    loginFormPath?: string;
+}


### PR DESCRIPTION
## Support for different login form path
Now you can pass an extra url indicating the location (relative to the initial url) of the login form. Useful since for doing the login, the login token is needed and sometimes the login form is not in the index

## Different way for retrieving courses
Instead of using arbitrary classes for retrieving courses and due date, now it uses the content of the url inside the href attributes to identify and retrieve them

If it does not work with the currently supported site, please let me know why so i can fix it